### PR TITLE
fixed memory management bugs

### DIFF
--- a/c-micrograd/engine.h
+++ b/c-micrograd/engine.h
@@ -72,8 +72,7 @@ Value* make_value(float x) {
  *     print_value(values[i]);  // Outputs: Value(val=1.00, grad=0.00), Value(val=2.00, grad=0.00), etc.
  * }
  */
-Value** make_values(float* arr) {
-    size_t len = sizeof(arr) / sizeof(arr[0]);
+Value** make_values(float* arr, size_t len) {
     // Allocate memory for an array of pointers to Value structures
     Value** values = (Value**)malloc(len * sizeof(Value*));
     if (values == NULL) {

--- a/c-micrograd/mlp.h
+++ b/c-micrograd/mlp.h
@@ -61,7 +61,7 @@ Value* neuron_forward(Neuron* neuron, Value** x) {
     }
     sum = add(sum, neuron->b);
     if (neuron->nonlin) {
-        Value* sum = leaky_relu(sum);
+        sum = leaky_relu(sum);
     }
 
     return sum;

--- a/c-micrograd/train.c
+++ b/c-micrograd/train.c
@@ -20,7 +20,9 @@ float* one_hot_encode(float y_true) {
 
 int main() {
     srand(43);  // seed the random number generator
-
+    
+    // inputs, in this case 1, an integer
+    int inputs=1;
     // labels, in this case 2, (odd (0) or even (1))
     int labels=2;
     // custom MLP with sizes [1, 5, 10, 5, 2]
@@ -48,10 +50,10 @@ int main() {
         for (int i=0; i < 25; i++) {
             
             float arr_x[] = {entries[i].number};
-            Value** x = make_values(arr_x);
+            Value** x = make_values(arr_x, inputs);
 
             float* arr_y = one_hot_encode(entries[i].label);
-            Value** y_true = make_values(arr_y);
+            Value** y_true = make_values(arr_y, labels);
 
             Value* loss = train(mlp, x, y_true, lr);
             total_loss = add(total_loss, loss);


### PR DESCRIPTION
This pull request fixes two bugs related to memory management in the C version of the implementation (found in the c-micrograd folder).

## Bug #1
<b>Original:</b> 

```C
Value** make_values(float* arr) {
    size_t len = sizeof(arr) / sizeof(arr[0]);
    // code
}
```

This results in unintended behavior because sizeof(arr) does not return the total number of bytes the array stores. It returns the size of the pointer to the array itself which is 4 or 8 bytes, regardless of the length of the array. As a result, I modified the function to take in "len" as an input and changed calls to the function where needed.


## Bug #2

<b>Original:</b>
```C
Value* neuron_forward(Neuron* neuron, Value** x) {
    Value* sum = make_value(0);
    // more code here
    if (neuron->nonlin) {
        Value* sum = leaky_relu(sum);
    }
    return sum;
}
```
This results in unintended behavior because it redeclares sum inside the scope of the if statement and, as a result, does not return the sum with leaky_relu applied to it. This also sometimes leads to segmentation faults during training. All I did to fix this was remove "Value *" from the line inside of the if statement.

<b>Fixed code:</b>

```C
Value* neuron_forward(Neuron* neuron, Value** x) {
    Value* sum = make_value(0);
    // more code here
    if (neuron->nonlin) {
        sum = leaky_relu(sum);
    }
    return sum;
}
```
